### PR TITLE
Add configurable home swipe detection

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -445,6 +445,10 @@
 
     <string name="pick_app_for_gesture">Pick app</string>
 
+    <string name="pref_home_swipe_vertical_distance">Vertical swipe threshold</string>
+    <string name="pref_home_swipe_horizontal_distance">Horizontal swipe threshold</string>
+    <string name="pref_home_swipe_velocity">Swipe velocity threshold</string>
+
     <string name="dt2s_admin_hint_title">Admin permissions required</string>
     <string name="dt2s_admin_hint">To use Double-Tap to Sleep, set Lawnchair as a device admin app. Tap \"Open settings\", then tap \"Activate this device admin app.\"</string>
     <string name="dt2s_admin_warning">Double-Tap to Sleep will be turned off.</string>

--- a/lawnchair/src/app/lawnchair/gestures/VerticalSwipeTouchController.kt
+++ b/lawnchair/src/app/lawnchair/gestures/VerticalSwipeTouchController.kt
@@ -31,6 +31,12 @@ class VerticalSwipeTouchController(
     private var currentVelocity = 0f
     private var currentDisplacement = 0f
 
+    private var minVerticalDistance =
+        prefs.homeSwipeVerticalMinDistance.defaultValue.toFloat()
+    private var minHorizontalDistance =
+        prefs.homeSwipeHorizontalMinDistance.defaultValue.toFloat()
+    private var minVelocity = prefs.homeSwipeTriggerVelocity.defaultValue
+
     private var triggered = false
 
     init {
@@ -40,6 +46,15 @@ class VerticalSwipeTouchController(
                 .launchIn(this)
             prefs.swipeDownGestureHandler.get()
                 .onEach { overrideSwipeDown = it != prefs.swipeDownGestureHandler.defaultValue }
+                .launchIn(this)
+            prefs.homeSwipeVerticalMinDistance.get()
+                .onEach { minVerticalDistance = it.toFloat() }
+                .launchIn(this)
+            prefs.homeSwipeHorizontalMinDistance.get()
+                .onEach { minHorizontalDistance = it.toFloat() }
+                .launchIn(this)
+            prefs.homeSwipeTriggerVelocity.get()
+                .onEach { minVelocity = it }
                 .launchIn(this)
         }
     }
@@ -73,12 +88,18 @@ class VerticalSwipeTouchController(
 
     override fun onDragStart(start: Boolean) {
         triggered = false
+        currentDisplacement = 0f
+        currentVelocity = 0f
+        currentMillis = 0L
     }
 
     override fun onDrag(displacement: PointF, motionEvent: MotionEvent): Boolean {
         if (triggered) return true
-        val velocity = computeVelocity(displacement.y - currentDisplacement, motionEvent.eventTime)
-        if (velocity.absoluteValue > TRIGGER_VELOCITY) {
+        val deltaY = displacement.y - currentDisplacement
+        val velocity = computeVelocity(deltaY, motionEvent.eventTime)
+        currentDisplacement = displacement.y
+        if (velocity.absoluteValue > minVelocity &&
+            displacement.y.absoluteValue > minVerticalDistance) {
             triggered = true
             if (velocity < 0) {
                 gestureController.onSwipeUp()
@@ -128,6 +149,5 @@ class VerticalSwipeTouchController(
 
     companion object {
         private const val SCROLL_VELOCITY_DAMPENING_RC = 1000f / (2f * Math.PI.toFloat() * 10f)
-        private const val TRIGGER_VELOCITY = 2.25f
     }
 }

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -606,6 +606,21 @@ class PreferenceManager2 private constructor(private val context: Context) : Pre
         defaultValue = GestureHandlerConfig.NoOp,
     )
 
+    val homeSwipeVerticalMinDistance = preference(
+        key = intPreferencesKey("home_swipe_vertical_min_distance"),
+        defaultValue = 30,
+    )
+
+    val homeSwipeHorizontalMinDistance = preference(
+        key = intPreferencesKey("home_swipe_horizontal_min_distance"),
+        defaultValue = 30,
+    )
+
+    val homeSwipeTriggerVelocity = preference(
+        key = floatPreferencesKey("home_swipe_trigger_velocity"),
+        defaultValue = 2.25f,
+    )
+
     private inline fun <reified T> serializablePreference(
         key: Preferences.Key<String>,
         defaultValue: T,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GesturePreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GesturePreferences.kt
@@ -7,6 +7,7 @@ import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.preferences.LocalIsExpandedScreen
 import app.lawnchair.ui.preferences.components.GestureHandlerPreference
+import app.lawnchair.ui.preferences.components.controls.SliderPreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import com.android.launcher3.R
@@ -41,6 +42,27 @@ fun GesturePreferences(
             GestureHandlerPreference(
                 adapter = prefs.backPressGestureHandler.getAdapter(),
                 label = stringResource(id = R.string.gesture_back_tap),
+            )
+            SliderPreference(
+                label = stringResource(id = R.string.pref_home_swipe_vertical_distance),
+                adapter = prefs.homeSwipeVerticalMinDistance.getAdapter(),
+                step = 1,
+                valueRange = 0..200,
+                showUnit = "px",
+            )
+            SliderPreference(
+                label = stringResource(id = R.string.pref_home_swipe_horizontal_distance),
+                adapter = prefs.homeSwipeHorizontalMinDistance.getAdapter(),
+                step = 1,
+                valueRange = 0..200,
+                showUnit = "px",
+            )
+            SliderPreference(
+                label = stringResource(id = R.string.pref_home_swipe_velocity),
+                adapter = prefs.homeSwipeTriggerVelocity.getAdapter(),
+                step = 0.05f,
+                valueRange = 0f..5f,
+                showUnit = "px/ms",
             )
         }
     }


### PR DESCRIPTION
## Summary
- expose preferences for customizing home swipe detection
- wire up slider preferences in gesture settings UI
- apply configurable thresholds when detecting home-screen swipes

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed462f988331ba0d0679886af3e9