### PR TITLE
Add customizable default home page

### DIFF
--- a/lawnchair/res/values-en-rGB/strings.xml
+++ b/lawnchair/res/values-en-rGB/strings.xml
@@ -488,6 +488,9 @@
     <string name="home_screen_locked">Home screen is locked</string>
     <string name="home_screen_lock_description">Prevent changes to the home screen layout</string>
 
+    <string name="home_screen_default_page">Default home page</string>
+    <string name="home_screen_default_page_description">Page opened with the Home gesture</string>
+
     <string name="show_dot_pagination_label">Show dot pagination</string>
     <string name="show_dot_pagination_description">Use dots instead of lines to show page number</string>
     <string name="show_material_u_popup_label">Use new pop-up style</string>

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -126,6 +126,8 @@
     <bool name="config_default_enable_material_u_popup">true</bool>
     <bool name="config_default_enable_two_line_allapps">true</bool>
 
+    <item name="config_default_home_page" type="dimen" format="integer">0</item>
+
     <item name="config_default_home_icon_size_factor" type="dimen" format="float">1.0</item>
     <item name="config_default_folder_preview_background_opacity" type="dimen" format="float">1.0</item>
     <item name="config_default_folder_background_opacity" type="dimen" format="float">1.0</item>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -505,6 +505,9 @@
     <string name="home_screen_locked">Home screen is locked</string>
     <string name="home_screen_lock_description">Prevent changes to the home screen layout</string>
 
+    <string name="home_screen_default_page">Default home page</string>
+    <string name="home_screen_default_page_description">Page opened with the Home gesture</string>
+
     <string name="show_dot_pagination_label">Show dot pagination</string>
     <string name="show_dot_pagination_description">Use dots instead of lines to show page number</string>
     <string name="show_material_u_popup_label">Use new pop-up style</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -266,6 +266,12 @@ class PreferenceManager2 private constructor(private val context: Context) : Pre
         onSet = { reloadHelper.reloadGrid() },
     )
 
+    val defaultHomePage = preference(
+        key = intPreferencesKey(name = "default_home_page"),
+        defaultValue = resourceProvider.getInt(R.dimen.config_default_home_page),
+        onSet = { reloadHelper.recreate() },
+    )
+
     val hideAppDrawerSearchBar = preference(
         key = booleanPreferencesKey(name = "hide_app_drawer_search_bar"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_hide_app_drawer_search_bar),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
@@ -116,6 +116,17 @@ fun HomeScreenPreferences(
                 destination = HomeScreenRoutes.GRID,
                 subtitle = stringResource(id = R.string.x_by_y, columns, rows),
             )
+            SliderPreference(
+                label = stringResource(id = R.string.home_screen_default_page),
+                adapter = rememberTransformAdapter(
+                    adapter = prefs2.defaultHomePage.getAdapter(),
+                    transformGet = { it + 1 },
+                    transformSet = { it - 1 },
+                ),
+                valueRange = 1..10,
+                step = 1,
+                description = stringResource(id = R.string.home_screen_default_page_description),
+            )
             DividerColumn {
                 SwitchPreference(
                     adapter = lockHomeScreenAdapter,

--- a/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/QuickstepLauncher.java
@@ -490,7 +490,7 @@ public class QuickstepLauncher extends Launcher {
             case HINT_STATE_ORDINAL: {
                 Workspace<?> workspace = getWorkspace();
                 getStateManager().goToState(NORMAL);
-                if (workspace.getNextPage() != Workspace.DEFAULT_PAGE) {
+                if (workspace.getNextPage() != workspace.getDefaultPageIndex()) {
                     workspace.post(workspace::moveToDefaultScreen);
                 }
                 break;

--- a/quickstep/src/com/android/launcher3/uioverrides/states/QuickstepAtomicAnimationFactory.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/states/QuickstepAtomicAnimationFactory.java
@@ -80,9 +80,7 @@ public class QuickstepAtomicAnimationFactory extends
     private static final float RECENTS_PREPARE_SCALE = 1.33f;
     // Scale workspace takes before animating in
     private static final float WORKSPACE_PREPARE_SCALE = 0.92f;
-    // Constants to specify how to scroll RecentsView to the default page if it's
-    // not already there.
-    private static final int DEFAULT_PAGE = 0;
+    // Default page index for RecentsView is taken from workspace preference.
     private static final int PER_PAGE_SCROLL_DURATION = 150;
     private static final int MAX_PAGE_SCROLL_DURATION = 750;
 
@@ -130,8 +128,9 @@ public class QuickstepAtomicAnimationFactory extends
                                 : clampToProgress(FAST_OUT_SLOW_IN, 0, 0.75f));
                 config.setInterpolator(ANIM_OVERVIEW_TRANSLATE_Y, FINAL_FRAME);
 
-                // Scroll RecentsView to page 0 as it goes offscreen, if necessary.
-                int numPagesToScroll = overview.getNextPage() - DEFAULT_PAGE;
+                // Scroll RecentsView to the default page as it goes offscreen, if necessary.
+                int defaultPage = mActivity.getWorkspace().getDefaultPageIndex();
+                int numPagesToScroll = overview.getNextPage() - defaultPage;
                 long scrollDuration = Math.min(MAX_PAGE_SCROLL_DURATION,
                         numPagesToScroll * PER_PAGE_SCROLL_DURATION);
                 config.duration = Math.max(config.duration, scrollDuration);
@@ -142,7 +141,7 @@ public class QuickstepAtomicAnimationFactory extends
                         && mActivity.getDeviceProfile().isTaskbarPresent) {
                     config.duration = Math.min(config.duration, TASKBAR_TO_HOME_DURATION);
                 }
-                overview.snapToPage(DEFAULT_PAGE, Math.toIntExact(config.duration));
+                overview.snapToPage(defaultPage, Math.toIntExact(config.duration));
             } else {
                 config.setInterpolator(ANIM_OVERVIEW_TRANSLATE_X, ACCELERATE_DECELERATE);
                 config.setInterpolator(ANIM_OVERVIEW_SCALE, clampToProgress(ACCELERATE, 0, 0.9f));

--- a/quickstep/src/com/android/quickstep/util/QuickstepOnboardingPrefs.java
+++ b/quickstep/src/com/android/quickstep/util/QuickstepOnboardingPrefs.java
@@ -102,7 +102,8 @@ public class QuickstepOnboardingPrefs extends OnboardingPrefs<QuickstepLauncher>
                         return;
                     }
                     mShouldIncreaseCount = toState == HINT_STATE
-                            && launcher.getWorkspace().getNextPage() == Workspace.DEFAULT_PAGE;
+                            && launcher.getWorkspace().getNextPage()
+                                    == launcher.getWorkspace().getDefaultPageIndex();
                 }
 
                 @Override

--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -1733,7 +1733,7 @@ public class Launcher extends StatefulActivity<LauncherState>
                 }
 
                 if (shouldMoveToDefaultScreen && !mWorkspace.isHandlingTouch()) {
-                    if (mWorkspace.getNextPage() != Workspace.DEFAULT_PAGE) {
+                    if (mWorkspace.getNextPage() != mWorkspace.getDefaultPageIndex()) {
                         mWorkspace.post(mWorkspace::moveToDefaultScreen);
                     } else {
                         handleHomeTap();

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -619,7 +619,7 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
      * Initializes various states for this workspace.
      */
     protected void initWorkspace() {
-        mCurrentPage = DEFAULT_PAGE;
+        mCurrentPage = getDefaultPageIndex();
         setClipToPadding(false);
 
         setupLayoutTransition();
@@ -3640,12 +3640,16 @@ public class Workspace<T extends View & PageIndicator> extends PagedView<T>
         return mOverlayShown;
     }
 
+    public int getDefaultPageIndex() {
+        return PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getDefaultHomePage());
+    }
+
     /**
-     * Calls {@link #snapToPage(int)} on the {@link #DEFAULT_PAGE}, then requests
+     * Calls {@link #snapToPage(int)} on the default home page, then requests
      * focus on it.
      */
     public void moveToDefaultScreen() {
-        int page = DEFAULT_PAGE;
+        int page = getDefaultPageIndex();
         if (!workspaceInModalState() && getNextPage() != page) {
             snapToPage(page);
         }


### PR DESCRIPTION
## Summary
- allow setting a custom default home page
- load page index from preferences when initializing and moving to home
- respect the new setting in Quickstep classes

## Testing
- `./gradlew assembleDebug` *(fails: Gradle download starts but build requires Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_684725d0fb84833180d40d22c05de8c9